### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ jobs:
         id: release-label
         if: ${{ steps.get-merged-pull-request.outputs.title != null }}
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: ${{ steps.get-merged-pull-request.outputs.labels }}
 
       - uses: actions-ecosystem/action-get-latest-tag@v1


### PR DESCRIPTION
## What this PR does / Why we need it

As you know (of course you are the author 😄 ), action-release-label seems to not have `github_token` as its input. [Sample](https://github.com/aximov/semver-sandbox/runs/1279465685?check_suite_focus=true#step:8:1)

Thank you for the great tools!

## Which issue(s) this PR fixes

None
